### PR TITLE
[WIP] Don't instantiate SimpleQueue until needed to allow execution from daemons and servers

### DIFF
--- a/src/mac_notifications/manager.py
+++ b/src/mac_notifications/manager.py
@@ -54,8 +54,10 @@ class NotificationManager(metaclass=Singleton):
         self._callback_listener_process: NotificationProcess | None = None
         # Specify that once we stop our application, self.cleanup should run
         atexit.register(self.cleanup)
+
         # Specify that when we get a keyboard interrupt, this function should handle it
-        signal.signal(signal.SIGINT, handler=self.catch_keyboard_interrupt)
+        if not MACOS_NOTIFICATIONS_AS_DAEMON:
+            signal.signal(signal.SIGINT, handler=self.catch_keyboard_interrupt)
 
     def create_callback_executor_thread(self) -> None:
         """Creates the callback executor thread and sets the _callback_executor_event."""

--- a/src/mac_notifications/manager.py
+++ b/src/mac_notifications/manager.py
@@ -12,7 +12,7 @@ from typing import Dict, List
 from mac_notifications.listener_process import NotificationProcess
 from mac_notifications.notification_config import MACOS_NOTIFICATIONS_AS_DAEMON, NotificationConfig
 from mac_notifications.singleton import Singleton
-from mac_notifications.notification_sender import cancel_notification
+from mac_notifications.notification_sender import cancel_notification, create_notification
 
 
 """
@@ -77,7 +77,7 @@ class NotificationManager(metaclass=Singleton):
         json_config = notification_config.to_json_notification()
 
         if MACOS_NOTIFICATIONS_AS_DAEMON:
-            notification_sender.create_notification(json_config, None).send()
+            create_notification(json_config, None).send()
         elif not notification_config.contains_callback or self._callback_listener_process is not None:
             # We can send it directly and kill the process after as we don't need to listen for callbacks.
             new_process = NotificationProcess(json_config, None)

--- a/src/mac_notifications/manager.py
+++ b/src/mac_notifications/manager.py
@@ -9,10 +9,10 @@ from multiprocessing import SimpleQueue
 from threading import Event, Thread
 from typing import Dict, List
 
-from mac_notifications import notification_sender
 from mac_notifications.listener_process import NotificationProcess
 from mac_notifications.notification_config import MACOS_NOTIFICATIONS_AS_DAEMON, NotificationConfig
 from mac_notifications.singleton import Singleton
+from mac_notifications.notification_sender import cancel_notification
 
 
 """
@@ -37,7 +37,7 @@ class Notification(object):
         self.uid = uid
 
     def cancel(self) -> None:
-        notification_sender.cancel_notification(self.uid)
+        cancel_notification(self.uid)
         clear_notification_from_existence(self.uid)
 
 

--- a/src/mac_notifications/notification_config.py
+++ b/src/mac_notifications/notification_config.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import timedelta
+from os import getenv
 from typing import Callable
 
 """
 The dataclasses that represent a Notification configuration.
 """
+
+# Some kinds of Python multiprocessing do not play nice with code that runs
+# continuously - servers, LaunchAgents, etc. By setting this environment
+# variable to True you can bypass the problematic parts and thus send
+# notifications from a daemon process.
+MACOS_NOTIFICATIONS_AS_DAEMON = getenv('MACOS_NOTIFICATIONS_AS_DAEMON', False)
 
 
 @dataclass

--- a/src/mac_notifications/notification_sender.py
+++ b/src/mac_notifications/notification_sender.py
@@ -8,7 +8,7 @@ from AppKit import NSImage
 from Foundation import NSDate, NSObject, NSURL, NSUserNotification, NSUserNotificationCenter
 from PyObjCTools import AppHelper
 
-from mac_notifications.notification_config import JSONNotificationConfig
+from mac_notifications.notification_config import MACOS_NOTIFICATIONS_AS_DAEMON, JSONNotificationConfig
 
 logger = logging.getLogger()
 

--- a/src/mac_notifications/notification_sender.py
+++ b/src/mac_notifications/notification_sender.py
@@ -8,7 +8,7 @@ from AppKit import NSImage
 from Foundation import NSDate, NSObject, NSURL, NSUserNotification, NSUserNotificationCenter
 from PyObjCTools import AppHelper
 
-from mac_notifications.notification_config import MACOS_NOTIFICATIONS_AS_DAEMON, JSONNotificationConfig
+from mac_notifications.notification_config import JSONNotificationConfig
 
 logger = logging.getLogger()
 


### PR DESCRIPTION
This is a pretty horrible and hacky workaround so I'm not sure you should actually merge this pull request but I figured it would be helpful for you to to see the v. limited changed I needed to get your code to work in the context of being run from a server or daemon. Maybe you have some better ideas about how to go about actually implementing this in your codebase? Happy to help.

[See discussion](https://github.com/Jorricks/macos-notifications/issues/23)